### PR TITLE
Fix corruption at end of unpacked files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,7 @@ impl Entry {
 
         for i in 0..(count%4) {
             buf[offset + i] ^= ((self.magic >> (maski * 8)) & 0xff) as u8;
+            maski += 1;
         }
 
         return count;


### PR DESCRIPTION
Hey! Thanks for the program!

Since `maski` wasn't updated in the final loop, a few bytes at the end of unpacked files were sometimes corrupted (depending on the length of the final read call). This should fix it.